### PR TITLE
feat: refactor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,19 +10,19 @@ const tsconfigs = {
   "react-native": tsconfigReactNative,
 };
 
-inquirer
-  .prompt([
+(async () => {
+  const { framework } = await inquirer.prompt([
     {
       type: "list",
       message: "Pick the framework you're using:",
       name: "framework",
       choices: ["react", "react-native", "node"]
     }
-  ])
-  .then(({ framework }) => {
-    const cwd = process.cwd();
+  ]);
 
-    writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsconfigs[framework], null, 2));
+  const cwd = process.cwd();
 
-    console.log("tsconfig.json successfully created");
-  });
+  writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsconfigs[framework], null, 2));
+
+  console.log("tsconfig.json successfully created");
+})()

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,13 @@
-const inquirer = require("inquirer");
 const { writeFileSync } = require("fs");
+const inquirer = require("inquirer");
+const tsconfigNode = require("./config/tsconfig.node.json");
+const tsconfigReact = require("./config/tsconfig.react.json");
+const tsconfigReactNative = require("./config/tsconfig.react-native.json");
 
 const tsconfigs = {
-  react: JSON.stringify(require("./config/tsconfig.react.json"), null, 2),
-  "react-native": JSON.stringify(
-    require("./config/tsconfig.react-native.json"),
-    null,
-    2
-  ),
-  node: JSON.stringify(require("./config/tsconfig.react-native.json"), null, 2)
+  "node": tsconfigNode,
+  "react": tsconfigReact,
+  "react-native": tsconfigReactNative,
 };
 
 inquirer
@@ -21,9 +20,9 @@ inquirer
     }
   ])
   .then(({ framework }) => {
-    const tsconfigToWrite = tsconfigs[framework];
-
     const cwd = process.cwd();
-    writeFileSync(cwd + "/tsconfig.json", tsconfigToWrite);
+
+    writeFileSync(`${cwd}/tsconfig.json`, JSON.stringify(tsconfigs[framework], null, 2));
+
     console.log("tsconfig.json successfully created");
   });


### PR DESCRIPTION
Refactor config assignment:
* sort import statements
* import configs on top of file
* map configs to config object
* use string template literals to concatenate variable and string
* write file using `JSON.stringify` to format it
* refactor Promises by using `async` / `await`

This is not only easier to read but also saves some resources.
Performing `JSON.stringify` is quite intensive and it is recommended to keep this to a minimum.