### PR TITLE
Extend tsconfig for node v14 runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,39 @@ const configFolderPath = path.resolve(__dirname, 'config');
     }
   ]);
 
-  const config = await readFile(configFiles[framework]).catch(console.log);
+  let config = await readFile(configFiles[framework]).catch(console.log);
 
   const tsconfig = path.join(process.cwd(), 'tsconfig.json');
 
+  if (framework === "node") {
+    const reg = new RegExp(/(?<=v)(\d+)/);
+    const version = parseInt(reg.exec(process.version)[0]);
+
+    if (version >= 14) {
+      // Optimal config for Node v14.0.0 (full ES2020)
+      const updateConfig = {
+        allowSyntheticDefaultImports: true,
+        lib: ["es2020"],
+        module: "es2020",
+        moduleResolution: "node",
+        target: "es2020",
+      };
+
+      const configObj = Object.keys(updateConfig).reduce((prev, curr) => {
+        return {
+          ...prev,
+          compilerOptions: {
+            ...prev.compilerOptions,
+            [curr]: updateConfig[curr],
+          },
+        };
+      }, JSON.parse(config.toString()));
+
+      config = JSON.stringify(configObj, null, 2);
+    }
+  }
+
   await writeFile(tsconfig, JSON.stringify(config.toString(), null, 2));
- 
+
   console.log("tsconfig.json successfully created");
-})()
+})();


### PR DESCRIPTION
Add additional code in `index.js` to extend the tsconfig with 'optimal' node 14 configs as per [this post](https://stackoverflow.com/questions/61305578/what-typescript-configuration-produces-output-closest-to-node-js-14-capabilities/61305579#61305579) pointed out in #8 .

If you think it's better to instead create a separate `tsconfig.node.14.json` which just `"extends": {"./tsconfig.node.json"` and holds the additional configs, I can update the PR
