### PR TITLE
Revert the addition of duplicated experimentalDecorators option

### DIFF
--- a/src/config/tsconfig.node.json
+++ b/src/config/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true,
     "target": "es6",
     "module": "commonjs",
     "lib": ["dom", "es6", "es2017", "esnext.asynciterable"],


### PR DESCRIPTION
This reverts commit b304ce5be8a7c02431ba814d0090c942e5daa5c7

### Issue

`experimentalDecorators` was already enabled. PR #15 adds a duplicated `experimentalDecorators`

https://github.com/benawad/tsconfig.json/blob/b304ce5be8a7c02431ba814d0090c942e5daa5c7/src/config/tsconfig.node.json#L2-L4

https://github.com/benawad/tsconfig.json/blob/b304ce5be8a7c02431ba814d0090c942e5daa5c7/src/config/tsconfig.node.json#L22-L24