### PR TITLE
Update default import configurations.

### DIFF
--- a/src/config/tsconfig.react-native.json
+++ b/src/config/tsconfig.react-native.json
@@ -16,6 +16,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/src/config/tsconfig.react.json
+++ b/src/config/tsconfig.react.json
@@ -18,7 +18,8 @@
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Now we can use `import React from "react"` rather than `import * as React from "react"`, which I personally think is cleaner.