### PR TITLE
Add path maps to `tsconfig.next.json`

### DIFF
--- a/src/config/tsconfig.nextjs.json
+++ b/src/config/tsconfig.nextjs.json
@@ -35,7 +35,6 @@
       "@component/*":["components/*", "src/components/*"],
       "@util/*":["lib/*","utils/*","util/*", "src/lib/*", "src/utils/*", "src/util/*"],
       "@lib/*":["lib/*","utils/*","util/*", "src/lib/*", "src/utils/*", "src/util/*"],
-      "@page/*":["pages/*", "src/pages/*"],
   },
   "include": [
     "next-env.d.ts",

--- a/src/config/tsconfig.nextjs.json
+++ b/src/config/tsconfig.nextjs.json
@@ -29,6 +29,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"
+    "baseUrl":"./",
+    "paths":{
+      "@style/*":["styles/*"],
+      "@component/*":["components/*", "src/components/*"],
+      "@util/*":["lib/*","utils/*","util/*", "src/lib/*", "src/utils/*", "src/util/*"],
+      "@lib/*":["lib/*","utils/*","util/*", "src/lib/*", "src/utils/*", "src/util/*"],
+      "@page/*":["pages/*", "src/pages/*"],
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Path maps are an incredibly useful feature of Typescript in my opinion. I figured I'd add path maps to this since Next has some fairly standard conventions.