### PR TITLE
fix(node): remove .tsx includes

### DIFF
--- a/src/config/tsconfig.node.json
+++ b/src/config/tsconfig.node.json
@@ -24,5 +24,5 @@
     "baseUrl": "."
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.tsx", "./src/**/*.ts"]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
I think "node" framework is meant to be a backend project. So why keep .tsx includes in tsconfig.json?