### PR TITLE
Update node.js config.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const configFolderPath = path.resolve(__dirname, 'config');
       const updateConfig = {
         allowSyntheticDefaultImports: true,
         lib: ["es2020"],
-        module: "es2020",
+        module: "commonjs",
         moduleResolution: "node",
         target: "es2020",
       };


### PR DESCRIPTION
As shown in issue #40, the compiled JavaScript code gives the error because the `module` option is es2020, so it keeps the `import` syntax (in fact, that is what's causing the problem). 
I updated index.js and switched the `module` option to commonjs and the error is resolved because we now use `require()` instead of the syntax `import {...} from "module"`.